### PR TITLE
feat: add spawn multiplier to speed up spawning

### DIFF
--- a/src/framework/emqttb_worker.erl
+++ b/src/framework/emqttb_worker.erl
@@ -280,6 +280,13 @@ model() ->
          , cli_short   => $A
          , target_node => [autorate]
          }}
+   , spawn_multiplier =>
+      {[value, cli_param],
+        #{ oneliner    => "Amount to multiply the spawn rate with"
+         , type        => pos_integer()
+         , default     => 1
+         , cli_operand => "spawn-multiplier"
+         }}
    , lowmem =>
        {[value, cli_param],
         #{ oneliner    => "Reduce memory useage at the cost of CPU wherever possible"


### PR DESCRIPTION
A bit hackyish, but I was able to use this to spawn clients at a reasonable rate to make it feasible for large tests (millions of clients).

```sh
env \
    EMQTTB_METRICS__PUSHGATEWAY__URL=http://lb.int.thales:9091 \
    /root/emqttb/emqttb \
    --restapi \
    --pushgw \
    --log-level info \
    @pubsub_fwd \
    --num-clients 2000000 \
    -I 9 \
    -i 50000 \
    @g -h emqx-0.int.thales:1883,emqx-1.int.thales:1883,emqx-2.int.thales:1883 \
    --spawn-multiplier 100 \
    --lowmem \
    --ifaddr "$(ip addr |grep -o '192.*/32' | sed 's#/32##g' | paste -s -d , -)"
```