### PR TITLE
feat: add extra options to pubsub_fwd scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: all
+.PHONY: all dialyzer compile
 all:
 	rebar3 do compile, dialyzer, escriptize, eunit, ct
+
+dialyzer:
+	rebar3 do dialyzer
+
+compile:
+	rebar3 do compile
 
 .PHONY: README.md
 README.md:

--- a/src/framework/emqttb_group.erl
+++ b/src/framework/emqttb_group.erl
@@ -41,6 +41,7 @@
          , behavior      := {module(), map()}
          , parent        => pid()
          , autorate      => atom()
+         , start_n       => integer()
          }.
 
 %%================================================================================
@@ -125,6 +126,7 @@ init([Conf]) ->
       #{ id         => ID
        , group_conf => ConfID
        }),
+  StartN = maps:get(start_n, Conf, 0),
   persistent_term:put(?GROUP_LEADER_TO_GROUP_ID(self()), ID),
   persistent_term:put(?GROUP_BEHAVIOR(self()), Behavior),
   persistent_term:put(?GROUP_CONF_ID(self()), ConfID),
@@ -138,6 +140,7 @@ init([Conf]) ->
         , tick_timer  = set_tick_timer()
         , parent_ref  = maybe_monitor_parent(Conf)
         , interval    = Autorate
+        , next_id     = StartN
         },
   {ok, S}.
 


### PR DESCRIPTION
- Adds the option to set the start number for worker IDs; this helps
align multiple bench hosts to distribute the connections evenly
amongst the target hosts, avoiding some hosts with more/less
connections and thus uneven memory usage.
- Add the option to use random hosts even in the pub-sub scenario to
give a simpler option if the above is not working as expected.