### PR TITLE
docs: Nicer documentation (thanks to Lee 0.4.3)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {deps,
   [ {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.8.2"}}}
-  , {lee, {git, "https://github.com/k32/lee", {tag, "0.4.2"}}}
+  , {lee, {git, "https://github.com/k32/lee", {tag, "0.4.3"}}}
   , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "1.0.1"}}}
   , {prometheus, {git, "https://github.com/deadtrickster/prometheus.erl", {tag, "v4.8.2"}}}
   , hackney


### PR DESCRIPTION
Change titles of sections from ugly key names (e.g. `[foo, bar]`) to oneliners that actually mean something.