### PR TITLE
bump versions of supported platforms and fix release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       matrix:
         otp:
-          - "25.1.2-3"
+          - "26.2.3-1"
         os:
-          - ubuntu20.04
+          - ubuntu24.04
     container:
-      image: ghcr.io/emqx/emqx-builder/5.0-34:1.13.4-${{ matrix.otp }}-${{ matrix.os }}
+      image: ghcr.io/emqx/emqx-builder/5.3-6:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
         fetch-depth: 0
     - name: Install additional packages
@@ -38,7 +38,7 @@ jobs:
     - if: failure()
       run: cat rebar3.crashdump
     - run: ./_build/default/bin/emqttb
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: packages
         path: ./*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/emqx/emqx-builder/5.0-34:1.13.4-25.1.2-3-ubuntu22.04
+      image: ghcr.io/emqx/emqx-builder/5.3-6:1.15.7-26.2.3-1-ubuntu24.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           make release
           tar czf docs.tar.gz _build/lee_doc/html _build/lee_doc/man _build/lee_doc/src/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: docs
           path: docs.tar.gz
@@ -56,29 +56,30 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - "25.1.2-3"
+          - "25.3.2-2"
+          - "26.2.3-1"
         os:
+          - ubuntu24.04
           - ubuntu22.04
           - ubuntu20.04
-          - ubuntu18.04
-          - ubuntu16.04
+          - debian12
           - debian11
           - debian10
-          - debian9
           - el9
           - el8
           - el7
           - amzn2
+          - amzn2023
     container:
-      image: ghcr.io/emqx/emqx-builder/5.0-34:1.13.4-${{ matrix.otp }}-${{ matrix.os }}
+      image: ghcr.io/emqx/emqx-builder/5.3-6:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: docs
           path: .
@@ -93,10 +94,10 @@ jobs:
       - if: failure()
         run: cat rebar3.crashdump
       - run: ./_build/default/bin/emqttb
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: packages
+          name: packages-${{ matrix.os }}-${{ matrix.otp }}
           path: ./*.tar.gz
 
   mac:
@@ -104,15 +105,17 @@ jobs:
       fail-fast: false
       matrix:
         macos:
-          - macos-12
+          - macos-13
+          - macos-14
         otp:
           - "25"
+          - "26"
 
     runs-on: ${{ matrix.macos }}
     needs: docs
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
@@ -121,7 +124,7 @@ jobs:
           brew install coreutils erlang@${{ matrix.otp }}
           brew link --force erlang@${{ matrix.otp }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: docs
           path: .
@@ -131,15 +134,16 @@ jobs:
         run: |
           tar xf docs.tar.gz
           export CAN_BUILD_DOCS=false
+          export BUILD_WITHOUT_QUIC=1
           make release
 
       - if: failure()
         run: cat rebar3.crashdump
       - run: ./_build/default/bin/emqttb
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: packages
+          name: packages-${{ matrix.macos }}-${{ matrix.otp }}
           path: ./*.tar.gz
 
   release:
@@ -150,12 +154,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') && !inputs.dryrun
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: packages
+          pattern: "packages-*"
           path: packages
+          merge-multiple: true
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,14 @@ jobs:
         shell: bash
         run: |
           tar xf docs.tar.gz
-          docker run -t --rm -v $(pwd):/emqttb -w /emqttb -e CAN_BUILD_DOCS=false -e REBAR=/usr/local/bin/rebar3 $EMQX_BUILDER bash -c 'git config --global --add safe.directory /emqttb && make release && timeout -s 9 5s ./emqttb @pub -t t/%n'
+          docker run -t --rm -v $(pwd):/emqttb -w /emqttb -e CAN_BUILD_DOCS=false -e REBAR=/usr/local/bin/rebar3 $EMQX_BUILDER bash -c 'git config --global --add safe.directory /emqttb && make release'
+      - name: Test
+        shell: bash
+        run: |
+          mkdir test-package
+          cp *.tar.gz test-package/
+          cd test-package
+          docker run -t --rm -v $(pwd):/emqttb -w /emqttb $EMQX_BUILDER bash -c 'tar xfz emqttb*.tar.gz && timeout -s 9 5s bin/emqttb @pub -t t/%n'
       - if: failure()
         run: cat rebar3.crashdump
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,8 @@ jobs:
           - el7
           - amzn2
           - amzn2023
-    container:
-      image: ghcr.io/emqx/emqx-builder/5.3-6:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
+    env:
+      EMQX_BUILDER: ghcr.io/emqx/emqx-builder/5.3-6:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
@@ -87,13 +87,10 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          git config --global --add safe.directory $(pwd)
           tar xf docs.tar.gz
-          export CAN_BUILD_DOCS=false
-          make release
+          docker run -t --rm -v $(pwd):/emqttb -w /emqttb -e CAN_BUILD_DOCS=false -e REBAR=/usr/local/bin/rebar3 $EMQX_BUILDER bash -c 'git config --global --add safe.directory /emqttb && make release && timeout -s 9 5s ./emqttb @pub -t t/%n'
       - if: failure()
         run: cat rebar3.crashdump
-      - run: ./_build/default/bin/emqttb
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: startsWith(github.ref, 'refs/tags/')
         with:

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -77,7 +77,7 @@ end,
 
 NewConfig =
 [ {escript_incl_apps,
-   [emqttb |
+   [emqttb, gproc |
     [ quicer || IsQuicSupp ]
    ]}
 , Profiles


### PR DESCRIPTION
- bump builder version to 5.3-6
- bump OTP versions to 25.3.2-2 and 26.2.3-1
- bump Elixir version to 1.15.7
- stop releasing packages for Ubuntu 16.04, Ubuntu 18.04 and Debian 9
- start releasing packages for Ubuntu 24.04, Debian 12 and Amazon Linux 2023
- disable QUIC when building macOS packages