### PR TITLE
fix: don't attempt to copy docs dirs if `CAN_BUILD_DOCS=false`

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -19,11 +19,27 @@ fun() ->
     {unix, darwin} =:= os:type()
 end,
 
+CanBuildDocs =
+fun() ->
+    "true" =:= os:getenv("CAN_BUILD_DOCS", "true")
+end,
+
 Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.111"}}},
 
 IsQuicSupp = not (IsCentos6() orelse IsWin32() orelse IsDarwin() orelse
                   false =/= os:getenv("BUILD_WITHOUT_QUIC")
                  ),
+
+CopyDocsSteps =
+case CanBuildDocs() of
+    true ->
+        [ {mkdir, "doc"}
+        , {copy, "_build/lee_doc/html/", "doc/html"}
+        , {copy, "_build/lee_doc/man/", "doc/man"}
+        ];
+    false ->
+        []
+end,
 
 Profiles =
 {profiles,
@@ -52,9 +68,7 @@ Profiles =
                         , {copy, "_build/emqttb/bin", "escript"}
                         , {copy, "bin/emqttb","bin/emqttb"}
                         , {template,"bin/emqttb","bin/emqttb"}
-                        , {mkdir, "doc"}
-                        , {copy, "_build/lee_doc/html/", "doc/html"}
-                        , {copy, "_build/lee_doc/man/", "doc/man"}
+                        | CopyDocsSteps
                         ]}
             , {dev_mode, false}
             , {include_src, false}


### PR DESCRIPTION
If disabled the source directory won't exist and fail the build.