### PR TITLE
ci(fix): macos-13 has been deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,8 @@ jobs:
       fail-fast: false
       matrix:
         macos:
-          - macos-13
           - macos-14
+          - macos-15
         otp:
           - "26"
 


### PR DESCRIPTION
```
The configuration 'macos-13-us-default' is not supported
```

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/